### PR TITLE
Adding trg_timer method to DDSCommandQueue without unit conversion

### DIFF
--- a/src/spcm/classes_dds_command_queue.py
+++ b/src/spcm/classes_dds_command_queue.py
@@ -141,3 +141,19 @@ class DDSCommandQueue(DDSCommandList):
         """
 
         self.set_d(SPC_DDS_CORE0_AMP_SLOPE + core_index, slope)
+
+    def trg_timer(self, period : float) -> None:
+        """
+        set the period at which the timer should raise DDS trigger events. (see register `SPC_DDS_TRG_TIMER` in the manual)
+
+        NOTE
+        ----
+        only used in conjecture with the trigger source set to SPCM_DDS_TRG_SRC_TIMER ---
+
+        Parameters
+        ----------
+        period : float
+            the time between DDS trigger events in seconds
+        """
+
+        self.set_d(SPC_DDS_TRG_TIMER, float(period))


### PR DESCRIPTION
Currently, whenever calling `DDSCommandQueue.trg_timer(period)`, the parent method `DDS.trg_timer(period)` is invoked.

This method performs a unit pint-style unit conversion for the `period`. This PR proposes to overwrite `trg_timer()` for command queues and skip the unit conversion. Since no unit conversion is performed for `DDSCommandQueue.freq` (and `amp`), this should be consistent.

Additionally, we identified a measurable performance increase with this change. When calling `trg_timer` 15000 times during the programming of the card, the time which can be allocated to `trg_timer` decreased by a factor of 1.8 (20ms vs 36ms for 15000 calls to `trg_timer`)